### PR TITLE
add test to bottom of file

### DIFF
--- a/wildboottest/wildboottest.py
+++ b/wildboottest/wildboottest.py
@@ -412,6 +412,8 @@ def wildboottest(model, param, cluster, B, weights_type = 'rademacher',impose_nu
   
   R = np.zeros(len(xnames))
   R[xnames.index(param)] = 1
+  # Just test for beta=0
+  # R = np.identity(len(xnames))
   
   # is it possible to fetch the clustering variables from the pre-processed data 
   # frame, e.g. with 'excluding' observations with missings etc
@@ -432,4 +434,33 @@ def wildboottest(model, param, cluster, B, weights_type = 'rademacher',impose_nu
   
   return boot.pvalue
   
+if __name__ == '__main__':
+    import statsmodels.api as sm
+    import numpy as np
 
+    np.random.seed(12312312)
+    N = 1000
+    k = 10
+    G= 10
+    X = np.random.normal(0, 1, N * k).reshape((N,k))
+    beta = np.random.normal(0,1,k)
+    beta[0] = 0.005
+    u = np.random.normal(0,1,N)
+    Y = 1 + X @ beta + u
+    cluster = np.random.choice(list(range(0,G)), N)
+
+    model = sm.OLS(Y, X)
+    
+    model.fit(cov_type='wildclusterbootstrap',
+              cov_kwds = {'cluster' : cluster,
+                          'B' : 9999,
+                          'weights_type' : 'rademacher',
+                          'impose_null' : True, 
+                          'bootstrap_type' : '11', 
+                          'seed' : None,
+                          'param' : 'X1'}).summary()
+    
+    
+
+    # boottest(model, param = "X1", cluster = cluster, B = 9999)
+    


### PR DESCRIPTION
In trying to figure out how to this into statsmodels, I opened this pull request so you can see my approach. For now, there's not much here, but I forked `statsmodels` and added support for linear models:

https://github.com/amichuda/statsmodels/pull/1

What I foresee us doing now is basically making the summary table be something like this:

```
                                 OLS Regression Results                                
=======================================================================================
Dep. Variable:                      y   R-squared (uncentered):                   0.737
Model:                            OLS   Adj. R-squared (uncentered):              0.735
Method:                 Least Squares   F-statistic:                              278.0
Date:                Mon, 17 Oct 2022   Prob (F-statistic):                   2.58e-279
Time:                        18:35:01   Log-Likelihood:                         -1769.6
No. Observations:                1000   AIC:                                      3559.
Df Residuals:                     990   BIC:                                      3608.
Df Model:                          10                                                  
Covariance Type:            nonrobust                                                  
==============================================================================
                 coef    std err          t      P>|t|      [0.025      0.975]
------------------------------------------------------------------------------
x1            -0.0457      0.045     -1.016      0.310      -0.134       0.043
x2            -1.1441      0.046    -24.947      0.000      -1.234      -1.054
x3             0.3851      0.047      8.243      0.000       0.293       0.477
x4            -0.6970      0.046    -15.284      0.000      -0.786      -0.607
x5            -0.5754      0.046    -12.380      0.000      -0.667      -0.484
x6             0.0367      0.046      0.790      0.430      -0.054       0.128
x7             0.2766      0.046      5.957      0.000       0.185       0.368
x8            -1.1516      0.044    -25.925      0.000      -1.239      -1.064
x9             0.5564      0.046     12.022      0.000       0.466       0.647
x10           -1.2981      0.046    -28.412      0.000      -1.388      -1.208
==============================================================================
Omnibus:                        0.445   Durbin-Watson:                   0.955
Prob(Omnibus):                  0.800   Jarque-Bera (JB):                0.327
Skew:                          -0.007   Prob(JB):                        0.849
Kurtosis:                       3.087   Cond. No.                         1.18
==============================================================================

Notes:
[1] R² is computed without centering (uncentered) since the model does not contain a constant.
[2] Standard Errors assume that the covariance matrix of the errors is correctly specified.
```